### PR TITLE
delete new-instance-name flag, since it can remain unchanged

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,9 @@ Compute Engine resources.
     3. If the original VM uses a Ephemeral internal/external IP and the user chooses to preserve it, then it will become a static internal/external IP after the migration.
     4. Support migrating a VM from a legacy network to a subnetwork, or from one VPC network to another. Within a network, a VM can also be migrated from one subnet to another. Migration from any network to a legacy network is not allowed.
     5. The original VM should only have one NIC.
-    6. The original VM and the new VM will have the same configuration except for the network interface and the instance name. Therefore, they are in the same project, same zone, and same region.
-    7. The new VM and the original VM must have different names.
-    8. The original VM must not be part of any instance group before changing the network it is associated with, since VMs in an instance group have to be in the same network. 
-    9. The original VM is assumed to be standalone. Other cases, for example, if the original instance is served as a backend of other services, such as load balancer, are not considered in the current scope.
+    6. The original VM and the new VM will have the same configuration except for the network interface. Therefore, they are in the same project, same zone, and same region.
+    7. The original VM must not be part of any instance group before changing the network it is associated with, since VMs in an instance group have to be in the same network. 
+    8. The original VM is assumed to be standalone. Other cases, for example, if the original instance is served as a backend of other services, such as load balancer, are not considered in the current scope.
 
 ## Before Running
     1. If not already done, enable the Compute Engine API
@@ -38,7 +37,7 @@ Compute Engine resources.
 ## Run
      python3 vm_network_migration.py --project_id=test-project
      --zone=us-central1-a --original_instance_name=instance-legacy
-     --new_instance_name=vm-new --network=test-network --subnetwork=test-network
+     --network=test-network --subnetwork=test-network
      --preserve_external_ip=False --preserve_internal_ip=False 
      --preserve_alias_ip=False
      

--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ Before running:
 Run the script by terminal, for example:
      python3 vm_network_migration.py --project_id=test-project
      --zone=us-central1-a --original_instance_name=instance-legacy
-     --new_instance_name=vm_network_migration-new --network=tests-network
+     --network=tests-network
      --subnetwork=tests-network --preserve_internal_ip=False
      --preserve_external_ip = False --preserve_alias_ip_ranges=False
 
@@ -65,6 +65,6 @@ if __name__ == '__main__':
 
     instance_migration = InstanceNetworkMigration(args.project_id, args.zone)
     instance_migration.network_migration(args.original_instance_name,
-                                         args.new_instance_name, args.network,
+                                         args.network,
                                          args.subnetwork,
                                          args.preserve_external_ip)

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -310,16 +310,6 @@ class TestAttachDisks(unittest.TestCase):
         self.assertEqual(instance.attach_disk.call_count, len(disks))
 
 
-class TestModifyInstanceTemplateWithNewName(unittest.TestCase):
-    def test_basic(self):
-        instance = mock.MagicMock()
-        instance.instance_template = {
-            "name": "original-instance"}
-        Instance.modify_instance_template_with_new_name(instance,
-                                                        "new-instance")
-        self.assertEqual(instance.instance_template["name"], "new-instance")
-
-
 class TestModifyInstanceTemplateWithNewNetwork(unittest.TestCase):
 
     def test_instance_with_subnet(self):

--- a/tests/test_instance_network_migration.py
+++ b/tests/test_instance_network_migration.py
@@ -185,7 +185,6 @@ class TestNetworkMigration(unittest.TestCase):
         instance_network_migration = InstanceNetworkMigration(self.project,
                                                               self.zone)
         instance_network_migration.network_migration("original-instance",
-                                                     "new-instance",
                                                      "mock-network",
                                                      "mock-subnetwork", False)
         new_instance_template = instance_network_migration.new_instance.instance_template
@@ -194,9 +193,7 @@ class TestNetworkMigration(unittest.TestCase):
 
         # compare two instance template
         for k, v in instance_template.items():
-            if k == "name":
-                self.assertNotEqual(new_instance_template["name"], v)
-            elif k == "networkInterfaces":
+            if k == "networkInterfaces":
                 pass
             else:
                 self.assertEqual(new_instance_template[k], v)
@@ -214,11 +211,9 @@ class TestNetworkMigration(unittest.TestCase):
         instance_network_migration = InstanceNetworkMigration(self.project,
                                                               self.zone)
         instance_network_migration.network_migration("original-instance",
-                                                     "new-instance",
                                                      "mock-network",
                                                      "mock-subnetwork", False)
         new_instance_template = instance_network_migration.new_instance.instance_template
-        self.assertEqual(new_instance_template["name"], "new-instance")
         self.assertTrue(
             "mock-network" in new_instance_template['networkInterfaces'][0][
                 'network'])
@@ -245,11 +240,9 @@ class TestNetworkMigration(unittest.TestCase):
         instance_network_migration = InstanceNetworkMigration(self.project,
                                                               self.zone)
         instance_network_migration.network_migration("original-instance",
-                                                     "new-instance",
                                                      "mock-network",
                                                      "mock-subnetwork", False)
         new_instance_template = instance_network_migration.new_instance.instance_template
-        self.assertEqual(new_instance_template["name"], "new-instance")
         self.assertTrue(
             "mock-network" in new_instance_template['networkInterfaces'][0][
                 'network'])
@@ -275,11 +268,9 @@ class TestNetworkMigration(unittest.TestCase):
         instance_network_migration = InstanceNetworkMigration(self.project,
                                                               self.zone)
         instance_network_migration.network_migration("original-instance",
-                                                     "new-instance",
                                                      "mock-network",
                                                      "mock-subnetwork", True)
         new_instance_template = instance_network_migration.new_instance.instance_template
-        self.assertEqual(new_instance_template["name"], "new-instance")
         self.assertTrue(
             "mock-network" in new_instance_template['networkInterfaces'][0][
                 'network'])
@@ -305,11 +296,10 @@ class TestNetworkMigration(unittest.TestCase):
         instance_network_migration = InstanceNetworkMigration(self.project,
                                                               self.zone)
         instance_network_migration.network_migration("original-instance",
-                                                     "new-instance",
                                                      "mock-network",
                                                      "mock-subnetwork", True)
         new_instance_template = instance_network_migration.new_instance.instance_template
-        self.assertEqual(new_instance_template["name"], "new-instance")
+
         self.assertTrue(
             "mock-network" in new_instance_template['networkInterfaces'][0][
                 'network'])
@@ -340,11 +330,10 @@ class TestNetworkMigration(unittest.TestCase):
         instance_network_migration = InstanceNetworkMigration(self.project,
                                                               self.zone)
         instance_network_migration.network_migration("original-instance",
-                                                     "new-instance",
                                                      "mock-network",
                                                      "mock-subnetwork", True)
         new_instance_template = instance_network_migration.new_instance.instance_template
-        self.assertEqual(new_instance_template["name"], "new-instance")
+
         self.assertTrue(
             "mock-network" in new_instance_template['networkInterfaces'][0][
                 'network'])
@@ -356,32 +345,6 @@ class TestNetworkMigration(unittest.TestCase):
             instance_template['networkInterfaces'][0]['accessConfigs'])
         instance_network_migration.new_instance.create_instance.assert_called()
         mocks[2].assert_not_called()
-
-    def test_unchanged_new_instance_name(self, *mocks):
-        instance_template = read_json_file(
-            "sample_instance_template_legacy_network.json")
-        network_template = read_json_file("sample_auto_mode_network.json")
-        request_builder = build_request_builder(instance_template,
-                                                network_template)
-        successResponse = httplib2.Response({
-            "status": 200,
-            "reason": "H"})
-        request_builder.responses["compute.networks.get"] = (
-            successResponse, b'')
-        compute = build("compute", "v1", self.http,
-                        requestBuilder=request_builder)
-        mocks[0].return_value = compute
-
-        instance_network_migration = InstanceNetworkMigration(self.project,
-                                                              self.zone)
-
-        instance_network_migration.network_migration("original-instance",
-                                                     "original-instance",
-                                                     "mock-network",
-                                                     "mock-subnetwork",
-                                                     False)
-        self.assertIsNone(instance_network_migration.new_instance)
-        mocks[2].assert_called()
 
     def test_no_subnetwork_in_auto_network_mode(self, *mocks):
         instance_template = read_json_file(
@@ -396,14 +359,12 @@ class TestNetworkMigration(unittest.TestCase):
         instance_network_migration = InstanceNetworkMigration(self.project,
                                                               self.zone)
         instance_network_migration.network_migration("original-instance",
-                                                     "new-instance",
                                                      "mock-network",
                                                      None,
                                                      False)
 
         new_instance_template = instance_network_migration.new_instance.instance_template
 
-        self.assertEqual(new_instance_template["name"], "new-instance")
         self.assertTrue(
             "mock-network" in new_instance_template['networkInterfaces'][0][
                 'network'])
@@ -427,7 +388,6 @@ class TestNetworkMigration(unittest.TestCase):
         instance_network_migration = InstanceNetworkMigration(self.project,
                                                               self.zone)
         instance_network_migration.network_migration("original-instance",
-                                                     "new-instance",
                                                      "mock-network",
                                                      None,
                                                      False)
@@ -453,12 +413,11 @@ class TestNetworkMigration(unittest.TestCase):
                                                               self.zone)
 
         instance_network_migration.network_migration("original-instance",
-                                                     "original-instance",
                                                      "mock-network",
                                                      "mock-subnetwork",
                                                      False)
-
         mocks[2].assert_called()
+
 
     def test_error_in_zones_get(self, *mocks):
         instance_template = read_json_file(
@@ -497,7 +456,6 @@ class TestNetworkMigration(unittest.TestCase):
                                                               self.zone)
 
         instance_network_migration.network_migration("original-instance",
-                                                     "new-instance",
                                                      "mock-network",
                                                      "mock-subnetwork",
                                                      False)
@@ -522,7 +480,6 @@ class TestNetworkMigration(unittest.TestCase):
         instance_network_migration = InstanceNetworkMigration(self.project,
                                                               self.zone)
         instance_network_migration.network_migration("original-instance",
-                                                     "new-instance",
                                                      "mock-network",
                                                      "mock-subnetwork",
                                                      False)
@@ -547,7 +504,6 @@ class TestNetworkMigration(unittest.TestCase):
         instance_network_migration = InstanceNetworkMigration(self.project,
                                                               self.zone)
         instance_network_migration.network_migration("original-instance",
-                                                     "new-instance",
                                                      "mock-network",
                                                      "mock-subnetwork",
                                                      False)
@@ -573,7 +529,6 @@ class TestNetworkMigration(unittest.TestCase):
                                                               self.zone)
 
         instance_network_migration.network_migration("original-instance",
-                                                     "new-instance",
                                                      "mock-network",
                                                      "mock-subnetwork",
                                                      False)
@@ -594,7 +549,6 @@ class TestNetworkMigration(unittest.TestCase):
                                                               self.zone)
         mocks[1].side_effect = Exception
         instance_network_migration.network_migration("original-instance",
-                                                     "new-instance",
                                                      "mock-network",
                                                      "mock-subnetwork",
                                                      False)
@@ -620,7 +574,6 @@ class TestNetworkMigration(unittest.TestCase):
                                                               self.zone)
         mocks[1].side_effect = Exception
         instance_network_migration.network_migration("original-instance",
-                                                     "new-instance",
                                                      "mock-network",
                                                      "mock-subnetwork",
                                                      False)

--- a/vm_network_migration/instance.py
+++ b/vm_network_migration/instance.py
@@ -168,18 +168,6 @@ class Instance(object):
         for diskInfo in disks:
             self.attach_disk(diskInfo['deviceName'])
 
-    def modify_instance_template_with_new_name(self, new_name):
-        """ Modify the instance template with the new name
-
-        Args:
-            new_name: new instance name
-
-        Returns: modified instance template
-
-        """
-        self.instance_template['name'] = new_name
-        return self.instance_template
-
     def modify_instance_template_with_new_network(self, new_network_link,
                                                   new_subnetwork_link) -> dict:
         """ Modify the instance template with the new network links
@@ -232,7 +220,6 @@ class Instance(object):
         """
         if self.address == None or self.network == None:
             raise AttributeNotExistError('Missing address or network object.')
-        self.modify_instance_template_with_new_name(self.name)
         self.modify_instance_template_with_external_ip(self.address.external_ip)
         self.modify_instance_template_with_new_network(
             self.network.network_link, self.network.subnetwork_link)

--- a/vm_network_migration/instance_network_migration.py
+++ b/vm_network_migration/instance_network_migration.py
@@ -34,7 +34,7 @@ Before running:
 Run the script by terminal, for example:
      python3 vm_network_migration.py --project_id=test-project
      --zone=us-central1-a --original_instance_name=instance-legacy
-     --new_instance_name=vm_network_migration-new --network=tests-network
+     --network=tests-network
      --subnetwork=tests-network --preserve_internal_ip=False
      --preserve_external_ip = False --preserve_alias_ip_ranges=False
 
@@ -121,14 +121,13 @@ class InstanceNetworkMigration:
 
         return network
 
-    def network_migration(self, original_instance_name, new_instance_name,
+    def network_migration(self, original_instance_name,
                           network_name,
                           subnetwork_name, preserve_external_ip):
         """ The main method of the instance network migration process
 
         Args:
             original_instance_name: original instance's name
-            new_instance_name: new instance's name
             network_name: target network name
             subnetwork_name: target subnetwork name
             preserve_external_ip: True/False
@@ -147,9 +146,6 @@ class InstanceNetworkMigration:
             if continue_execution == 'n':
                 preserve_external_ip = False
         try:
-            if new_instance_name == original_instance_name:
-                raise UnchangedInstanceNameError(
-                    'The new VM should not have the same name as the original VM. The migration process didn\'t start')
             print('Retrieving the original instance template.')
             self.original_instance = Instance(self.compute, self.project,
                                               original_instance_name,
@@ -157,7 +153,7 @@ class InstanceNetworkMigration:
                                               self.zone, None)
 
             self.new_instance = Instance(self.compute, self.project,
-                                         new_instance_name,
+                                         original_instance_name,
                                          self.region, self.zone, copy.deepcopy(
                     self.original_instance.instance_template))
             self.new_instance.address = self.generate_address(


### PR DESCRIPTION
1. No need of the new-instance-name, because we delete the original instance and then create the new one. So they can have the same the same name.