### PR TITLE
Add health check waiting for backend service migration

### DIFF
--- a/vm_network_migration/modules/backend_service_modules/backend_service.py
+++ b/vm_network_migration/modules/backend_service_modules/backend_service.py
@@ -88,7 +88,7 @@ class BackendService(object):
         """
         start = datetime.now()
         print('Waiting for %s being healthy with time out %s seconds.' %(backend_selfLink, TIME_OUT))
-        while not self.check_backend_health(self, backend_selfLink):
+        while not self.check_backend_health(backend_selfLink):
             time.sleep(3)
             current_time = datetime.now()
             if (current_time-start).seconds > TIME_OUT:

--- a/vm_network_migration/modules/backend_service_modules/backend_service.py
+++ b/vm_network_migration/modules/backend_service_modules/backend_service.py
@@ -14,8 +14,10 @@
 
 """ BackendService class: describe a backend service.
 """
-from vm_network_migration.utils import initializer
 import logging
+from datetime import datetime
+import time
+from vm_network_migration.utils import initializer
 
 
 class BackendService(object):
@@ -40,7 +42,7 @@ class BackendService(object):
             '-------Backend Service: %s-----' % (self.backend_service_name))
         logging.info(self.backend_service_configs)
         logging.info('--------------------------')
-        
+
     def get_backend_service_configs(self):
         pass
 
@@ -63,3 +65,33 @@ class BackendService(object):
 
     def compare_original_network_and_target_network(self):
         return False
+
+    def check_backend_health(self, backend_selfLink):
+        """ Check if the backends is healthy
+
+        Args:
+            backends_selfLink: url selfLink of the backends (just an instance group)
+
+        Returns:
+
+        """
+        pass
+
+    def wait_for_backend_become_healthy(self, backend_selfLink, TIME_OUT = 600):
+        """ Wait for backend being healthy
+
+        Args:
+            backend_selfLink: url selfLink of the backends (just an instance group)
+
+        Returns:
+
+        """
+        start = datetime.now()
+        print('Waiting for %s being healthy with time out %s seconds.' %(backend_selfLink, TIME_OUT))
+        while not self.check_backend_health(self, backend_selfLink):
+            time.sleep(3)
+            current_time = datetime.now()
+            if (current_time-start).seconds > TIME_OUT:
+                print('Health waiting operation is timed out.')
+                return
+        print('%s is healthy.' %(backend_selfLink))

--- a/vm_network_migration/modules/backend_service_modules/backend_service.py
+++ b/vm_network_migration/modules/backend_service_modules/backend_service.py
@@ -94,4 +94,4 @@ class BackendService(object):
             if (current_time-start).seconds > TIME_OUT:
                 print('Health waiting operation is timed out.')
                 return
-        print('%s is healthy.' %(backend_selfLink))
+        print('At least one of the instances in %s is healthy.' %(backend_selfLink))

--- a/vm_network_migration/modules/backend_service_modules/global_backend_service.py
+++ b/vm_network_migration/modules/backend_service_modules/global_backend_service.py
@@ -20,7 +20,7 @@ from copy import deepcopy
 
 from vm_network_migration.modules.backend_service_modules.backend_service import BackendService
 from vm_network_migration.modules.other_modules.operations import Operations
-from vm_network_migration.utils import is_equal_or_contians
+from vm_network_migration.utils import instance_group_links_is_equal
 
 
 class GlobalBackendService(BackendService):
@@ -67,7 +67,7 @@ class GlobalBackendService(BackendService):
         updated_backend_service['backends'] = [v for v in
                                                updated_backend_service[
                                                    'backends'] if
-                                               not is_equal_or_contians(
+                                               not instance_group_links_is_equal(
                                                    v['group'],
                                                    backend_selfLink)]
         args = {

--- a/vm_network_migration/modules/backend_service_modules/global_backend_service.py
+++ b/vm_network_migration/modules/backend_service_modules/global_backend_service.py
@@ -154,8 +154,13 @@ class GlobalBackendService(BackendService):
             body={
                 "group": backend_selfLink
             }).execute()
-        if 'healthStatus' not in operation or operation[
-            'healthStatus'] != 'HEALTHY':
+        if 'healthStatus' not in operation:
             return False
-
+        else:
+            for instance_health_status in operation['healthStatus']:
+                # If any instance in this backend becomes healthy,
+                # this backend will start serving the backend service
+                if 'healthState' in instance_health_status and \
+                        instance_health_status['healthState'] == 'HEALTHY':
+                    return True
         return True

--- a/vm_network_migration/modules/backend_service_modules/global_backend_service.py
+++ b/vm_network_migration/modules/backend_service_modules/global_backend_service.py
@@ -38,9 +38,9 @@ class GlobalBackendService(BackendService):
             of the instances serving the backends
         """
         super(GlobalBackendService, self).__init__(compute, project,
-                                                     backend_service_name,
-                                                     network, subnetwork,
-                                                     preserve_instance_external_ip)
+                                                   backend_service_name,
+                                                   network, subnetwork,
+                                                   preserve_instance_external_ip)
         self.backend_service_configs = self.get_backend_service_configs()
         self.operations = Operations(self.compute, self.project)
         self.preserve_instance_external_ip = preserve_instance_external_ip
@@ -138,3 +138,24 @@ class GlobalBackendService(BackendService):
                 previous_request=request,
                 previous_response=response)
         return forwarding_rule_list
+
+    def check_backend_health(self, backend_selfLink) -> bool:
+        """ Check if the backends is healthy
+
+        Args:
+            backends_selfLink: url selfLink of the backends (just an instance group)
+
+        Returns:
+
+        """
+        operation = self.compute.backendServices().getHealth(
+            project=self.project,
+            backendService=self.backend_service_name,
+            body={
+                "group": backend_selfLink
+            }).execute()
+        if 'healthStatus' not in operation or operation[
+            'healthStatus'] != 'HEALTHY':
+            return False
+
+        return True

--- a/vm_network_migration/modules/backend_service_modules/internal_backend_service.py
+++ b/vm_network_migration/modules/backend_service_modules/internal_backend_service.py
@@ -18,11 +18,10 @@ TCP/UDP internal load balancer. It is always regional.
 """
 from copy import deepcopy
 
+from googleapiclient.http import HttpError
 from vm_network_migration.module_helpers.subnet_network_helper import SubnetNetworkHelper
 from vm_network_migration.modules.backend_service_modules.backend_service import BackendService
 from vm_network_migration.modules.other_modules.operations import Operations
-from googleapiclient.http import HttpError
-import logging
 
 
 class InternalBackendService(BackendService):
@@ -174,3 +173,27 @@ class InternalBackendService(BackendService):
                 previous_request=request,
                 previous_response=response)
         return forwarding_rule_list
+
+    def check_backend_health(self, backend_selfLink) -> bool:
+        """ Check if the backends is healthy
+
+        Args:
+            backends_selfLink: url selfLink of the backends (just an instance group)
+
+        Returns:
+
+        """
+        operation = self.compute.regionBackendServices().getHealth(
+            project=self.project,
+            region=self.region,
+            backendService=self.backend_service_name,
+            body={
+                "group": backend_selfLink
+            }).execute()
+        if 'healthStatus' not in operation or operation[
+            'healthStatus'] != 'HEALTHY':
+            return False
+
+        return True
+
+

--- a/vm_network_migration/modules/backend_service_modules/internal_self_managed_backend_service.py
+++ b/vm_network_migration/modules/backend_service_modules/internal_self_managed_backend_service.py
@@ -16,11 +16,7 @@ TCP/UDP external load balancer or an HTTP external load balancer.
 It is always a global compute engine resource.
 
 """
-from copy import deepcopy
 
-from vm_network_migration.modules.backend_service_modules.backend_service import BackendService
-from vm_network_migration.modules.other_modules.operations import Operations
-from vm_network_migration.utils import is_equal_or_contians
 from vm_network_migration.modules.backend_service_modules.global_backend_service import GlobalBackendService
 
 
@@ -38,7 +34,9 @@ class InternalSelfManagedBackendService(GlobalBackendService):
             preserve_instance_external_ip: whether to preserve the external IPs
             of the instances serving the backends
         """
-        super(InternalSelfManagedBackendService, self).__init__(compute, project,
-                                                     backend_service_name,
-                                                     network, subnetwork,
-                                                     preserve_instance_external_ip)
+        super(InternalSelfManagedBackendService, self).__init__(compute,
+                                                                project,
+                                                                backend_service_name,
+                                                                network,
+                                                                subnetwork,
+                                                                preserve_instance_external_ip)

--- a/vm_network_migration/utils.py
+++ b/vm_network_migration/utils.py
@@ -86,3 +86,17 @@ def is_equal_or_contians(url1, url2):
 
     """
     return url1 == url2 or url1 in url2 or url2 in url1
+
+def instance_group_links_is_equal(url1, url2) -> bool:
+    """ Compare two instance group selfLinks
+
+    Args:
+        url1: selfLink of group1
+        url2: selfLink of group2
+
+    Returns:
+
+    """
+    url1 = url1.replace('/instanceGroupManagers/','/instanceGroups/' )
+    url2 = url2.replace('/instanceGroupManagers/','/instanceGroups/' )
+    return is_equal_or_contians(url1, url2)


### PR DESCRIPTION
1. Add health check related functions.
2. To eliminate the downtime during the 'INTERNAL_SELF_MANAGED' or 'EXTERNAL' backend service migration, the tool will wait for the first migrated backend becoming partially healthy before starting migrate the next backend. Default waiting time_out = 600 seconds.
