### PR TITLE
Add health check waiting feature for target pool migration

### DIFF
--- a/vm_network_migration/handlers/target_pool_migration/target_pool_migration.py
+++ b/vm_network_migration/handlers/target_pool_migration/target_pool_migration.py
@@ -16,12 +16,12 @@
 """
 import warnings
 
+from googleapiclient.errors import HttpError
 from vm_network_migration.errors import *
 from vm_network_migration.handler_helper.selfLink_executor import SelfLinkExecutor
+from vm_network_migration.handlers.compute_engine_resource_migration import ComputeEngineResourceMigration
 from vm_network_migration.modules.target_pool_modules.target_pool import TargetPool
 from vm_network_migration.utils import initializer
-from vm_network_migration.handlers.compute_engine_resource_migration import ComputeEngineResourceMigration
-from googleapiclient.errors import HttpError
 
 
 class TargetPoolMigration(ComputeEngineResourceMigration):
@@ -101,7 +101,9 @@ class TargetPoolMigration(ComputeEngineResourceMigration):
         """
         print('Migrating the target pool: %s' % (self.target_pool_name))
         try:
-            total_number_of_backend_handlers = len(self.instance_migration_handlers) + len(self.instance_group_migration_handlers)
+            total_number_of_backend_handlers = len(
+                self.instance_migration_handlers) + len(
+                self.instance_group_migration_handlers)
             for i in range(len(self.instance_migration_handlers)):
                 instance_migration_handler = self.instance_migration_handlers[i]
                 print('Migrating: %s.'
@@ -111,20 +113,27 @@ class TargetPoolMigration(ComputeEngineResourceMigration):
                 instance_selfLink = instance_migration_handler.get_instance_selfLink()
                 self.target_pool.add_instance(instance_selfLink)
                 if i == 0 and total_number_of_backend_handlers > 1:
-                    self.target_pool.wait_for_backend_become_healthy(instance_selfLink)
+                    self.target_pool.wait_for_instance_become_healthy(
+                        instance_selfLink)
 
-            for instance_group_migration_handler in self.instance_group_migration_handlers:
+            for i in range(len(self.instance_group_migration_handlers)):
+                instance_group_migration_handler = \
+                self.instance_group_migration_handlers[i]
                 print('Migrating: %s.'
                       % (instance_group_migration_handler.instance_group_name))
                 instance_group_migration_handler.network_migration()
+                if len(self.instance_migration_handlers) == 0 \
+                        and i == 0 and total_number_of_backend_handlers > 1:
+                    self.target_pool.wait_for_an_instance_group_become_partially_healthy(
+                        instance_group_migration_handler.instance_group)
 
         except Exception as e:
-                warnings.warn(e, Warning)
-                print(
-                    'The target pool migration was failed. '
-                    'Rolling back to its original network.')
-                self.rollback()
-                raise MigrationFailed('Rollback finished.')
+            warnings.warn(e, Warning)
+            print(
+                'The target pool migration was failed. '
+                'Rolling back to its original network.')
+            self.rollback()
+            raise MigrationFailed('Rollback finished.')
 
     def rollback(self):
         """ Rollback
@@ -135,13 +144,16 @@ class TargetPoolMigration(ComputeEngineResourceMigration):
         warnings.warn('Rolling back: %s.' % (self.target_pool_name), Warning)
         for instance_migration_handler in self.instance_migration_handlers:
             instance_migration_handler.rollback()
-            print('Reattaching the instance (%s) to the target pool' %(instance_migration_handler.original_instance_name))
+            print('Reattaching the instance (%s) to the target pool' % (
+                instance_migration_handler.original_instance_name))
             self.target_pool.add_instance(
                 instance_migration_handler.get_instance_selfLink())
 
         for instance_group_migration_handler in self.instance_group_migration_handlers:
             instance_group_migration_handler.rollback()
             if instance_group_migration_handler.instance_group != None:
-                print('Reattaching the instance group (%s) to the target pool' %(instance_group_migration_handler.instance_group_name))
+                print(
+                    'Reattaching the instance group (%s) to the target pool' % (
+                        instance_group_migration_handler.instance_group_name))
                 instance_group_migration_handler.instance_group.set_target_pool(
                     self.target_pool.selfLink)

--- a/vm_network_migration/module_helpers/subnet_network_helper.py
+++ b/vm_network_migration/module_helpers/subnet_network_helper.py
@@ -19,7 +19,7 @@ from vm_network_migration.utils import initializer
 
 class SubnetNetworkHelper:
     @initializer
-    def __init__(self, compute, project, zone, region, only_check_network_info=False):
+    def __init__(self, compute, project, zone, region=None, only_check_network_info=False):
         """ Initialization
 
         Args:

--- a/vm_network_migration/modules/backend_service_modules/global_backend_service.py
+++ b/vm_network_migration/modules/backend_service_modules/global_backend_service.py
@@ -163,4 +163,4 @@ class GlobalBackendService(BackendService):
                 if 'healthState' in instance_health_status and \
                         instance_health_status['healthState'] == 'HEALTHY':
                     return True
-        return True
+        return False

--- a/vm_network_migration/modules/instance_group_modules/instance_group.py
+++ b/vm_network_migration/modules/instance_group_modules/instance_group.py
@@ -20,6 +20,7 @@ from googleapiclient.http import HttpError
 from vm_network_migration.utils import initializer
 import logging
 
+
 class InstanceGroup(object):
     @initializer
     def __init__(self, compute, project, instance_group_name, network_name,
@@ -44,7 +45,8 @@ class InstanceGroup(object):
 
         """
         logging.basicConfig(filename='backup.log', level=logging.INFO)
-        logging.info('-------Instance Group: %s-----' % (self.instance_group_name))
+        logging.info(
+            '-------Instance Group: %s-----' % (self.instance_group_name))
         logging.info(self.original_instance_group_configs)
         logging.info('--------------------------')
 
@@ -65,6 +67,14 @@ class InstanceGroup(object):
             else:
                 raise e
         return InstanceGroupStatus('EXISTS')
+
+    def list_instances(self):
+        """ get a list of instances' selfLinks which are in this group
+
+        Returns: a list of selfLinks
+
+        """
+        pass
 
     def get_selfLink(self, config):
         """ Get the selfLink from config
@@ -98,6 +108,7 @@ class InstanceGroup(object):
 
     def compare_original_network_and_target_network(self):
         return False
+
 
 class InstanceGroupStatus(Enum):
     """

--- a/vm_network_migration/modules/instance_group_modules/managed_instance_group.py
+++ b/vm_network_migration/modules/instance_group_modules/managed_instance_group.py
@@ -273,3 +273,24 @@ class ManagedInstanceGroup(InstanceGroup):
     def get_target_pools(self, configs):
         """Get a list of target pools served by the instance group"""
         return configs['targetPools']
+
+    def list_instances(self) -> list:
+        """ List managed instances' selfLinks
+
+        Returns: a list of instances' selfLinks
+
+        """
+        instance_selfLinks = []
+        args = {
+            'project': self.project,
+            'instanceGroupManager': self.instance_group_name,
+
+        }
+        self.add_zone_or_region_into_args(args)
+        list_instances_operation = self.instance_group_manager_api.setTargetPools(
+            **args).execute()
+
+        for item in list_instances_operation['managedInstances']:
+            if item['instanceStatus'] == 'RUNNING':
+                instance_selfLinks.append(item['instance'])
+        return instance_selfLinks

--- a/vm_network_migration/modules/instance_group_modules/managed_instance_group.py
+++ b/vm_network_migration/modules/instance_group_modules/managed_instance_group.py
@@ -287,7 +287,7 @@ class ManagedInstanceGroup(InstanceGroup):
 
         }
         self.add_zone_or_region_into_args(args)
-        list_instances_operation = self.instance_group_manager_api.setTargetPools(
+        list_instances_operation = self.instance_group_manager_api.listManagedInstances(
             **args).execute()
 
         for item in list_instances_operation['managedInstances']:

--- a/vm_network_migration/modules/instance_group_modules/unmanaged_instance_group.py
+++ b/vm_network_migration/modules/instance_group_modules/unmanaged_instance_group.py
@@ -58,7 +58,7 @@ class UnmanagedInstanceGroup(InstanceGroup):
     def get_network(self):
         print('Checking the target network information.')
         subnetwork_factory = SubnetNetworkHelper(self.compute, self.project,
-                                                 self.zone, self.region)
+                                                 self.zone)
         network = subnetwork_factory.generate_network(
             self.network_name,
             self.subnetwork_name)

--- a/vm_network_migration/modules/instance_group_modules/unmanaged_instance_group.py
+++ b/vm_network_migration/modules/instance_group_modules/unmanaged_instance_group.py
@@ -45,7 +45,7 @@ class UnmanagedInstanceGroup(InstanceGroup):
                                                      subnetwork_name,
                                                      preserve_instance_ip)
         self.zone = zone
-        self.instance_selfLinks = self.retrieve_instances()
+        self.instance_selfLinks = self.list_instances()
         self.network = self.get_network()
         self.original_instance_group_configs = self.get_instance_group_configs()
         self.new_instance_group_configs = self.get_new_instance_group_configs_using_new_network(
@@ -74,7 +74,7 @@ class UnmanagedInstanceGroup(InstanceGroup):
                                                  zone=self.zone,
                                                  instanceGroup=self.instance_group_name).execute()
 
-    def retrieve_instances(self):
+    def list_instances(self):
         """Retrieve all the instances in this instance group,
         and save the instances into a list of Instance objects
 

--- a/vm_network_migration/modules/instance_group_modules/unmanaged_instance_group.py
+++ b/vm_network_migration/modules/instance_group_modules/unmanaged_instance_group.py
@@ -45,10 +45,7 @@ class UnmanagedInstanceGroup(InstanceGroup):
                                                      subnetwork_name,
                                                      preserve_instance_ip)
         self.zone = zone
-        self.region = self.get_region()
-        self.instances = []
-        self.instance_selfLinks = []
-        self.retrieve_instances()
+        self.instance_selfLinks = self.retrieve_instances()
         self.network = self.get_network()
         self.original_instance_group_configs = self.get_instance_group_configs()
         self.new_instance_group_configs = self.get_new_instance_group_configs_using_new_network(
@@ -57,19 +54,6 @@ class UnmanagedInstanceGroup(InstanceGroup):
         self.operation = Operations(self.compute, self.project, self.zone, None)
         self.selfLink = self.get_selfLink(self.original_instance_group_configs)
         self.log()
-
-    def get_region(self) -> dict:
-        """ Get region information
-
-            Returns:
-                region name of the self.zone
-
-            Raises:
-                googleapiclient.errors.HttpError: invalid request
-        """
-        return self.compute.zones().get(
-            project=self.project,
-            zone=self.zone).execute()['region'].split('regions/')[1]
 
     def get_network(self):
         print('Checking the target network information.')
@@ -97,8 +81,7 @@ class UnmanagedInstanceGroup(InstanceGroup):
         Returns: a list of Instance objects
 
         """
-        self.instances = []
-        self.instance_selfLinks = []
+        instance_selfLinks = []
         request = self.compute.instanceGroups().listInstances(
             project=self.project, zone=self.zone,
             instanceGroup=self.instance_group_name)
@@ -109,17 +92,11 @@ class UnmanagedInstanceGroup(InstanceGroup):
                 break
             for instance_with_named_ports in response['items']:
                 print(instance_with_named_ports)
-                instance_name = \
-                    instance_with_named_ports['instance'].split('instances/')[1]
-                self.instances.append(
-                    Instance(self.compute, self.project, instance_name,
-                             self.region, self.zone, self.network_name,
-                             self.subnetwork_name,
-                             preserve_instance_ip=self.preserve_instance_ip))
-                self.instance_selfLinks.append(
+                instance_selfLinks.append(
                     instance_with_named_ports['instance'])
             request = self.compute.instanceGroups().listInstances_next(
                 previous_request=request, previous_response=response)
+        return instance_selfLinks
 
     def delete_instance_group(self) -> dict:
         """ Delete the instance group in the compute engine
@@ -148,10 +125,6 @@ class UnmanagedInstanceGroup(InstanceGroup):
             body=configs).execute()
         self.operation.wait_for_zone_operation(
             create_instance_group_operation['name'])
-        if configs == self.original_instance_group_configs:
-            self.migrated = False
-        elif configs == self.new_instance_group_configs:
-            self.migrated = True
         return create_instance_group_operation
 
     def add_an_instance(self, instance_selfLink):
@@ -211,13 +184,13 @@ class UnmanagedInstanceGroup(InstanceGroup):
                 raise e
 
     def add_all_instances(self):
-        """ Add all the instances in self.instances to the current instance group
+        """ Add all the instances in instances to the current instance group
         Returns:
 
         """
-        for instance in self.instances:
+        for instance_selfLink in self.instance_selfLinks:
             try:
-                self.add_an_instance(instance.selfLink)
+                self.add_an_instance(instance_selfLink)
             except HttpError:
                 raise AddInstanceToInstanceGroupError(
                     'Failed to add all instances to the instance group.')


### PR DESCRIPTION
1.  If there are two or more backends serving a target pool, the tool will wait for the first backend becoming healthy, then continue with other backends.
2.  Delete some unused parameters.